### PR TITLE
Update transaction.js

### DIFF
--- a/src/transaction.js
+++ b/src/transaction.js
@@ -369,7 +369,10 @@ Transaction.prototype.clone = function () {
   newTx.version = this.version
   newTx.locktime = this.locktime
   newTx.zcash = this.zcash
-
+  if (newTx.zcash) {
+    newTx.versionGroupId = this.versionGroupId
+    newTx.expiry = this.expiry
+  }
   newTx.ins = this.ins.map(function (txIn) {
     return {
       hash: txIn.hash,

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -29,6 +29,13 @@ function Transaction () {
   this.joinsplits = []
 }
 
+Transaction.prototype.setOverwinter = function (expiry, versionGroupId, version) {
+  this.zcash = true;
+  this.version = Math.max((version||3), 3);
+  this.versionGroupId=(versionGroupId||0x03c48270);
+  this.expiry=(expiry||0);
+}
+
 Transaction.DEFAULT_SEQUENCE = 0xffffffff
 Transaction.SIGHASH_ALL = 0x01
 Transaction.SIGHASH_NONE = 0x02


### PR DESCRIPTION
Allow setting overwinter when generating coinbase tx

Parameters are optional for `tx.setOverwinter()`
Default Zcash overwinter values will be used if not provided.

Example usage:
```
var tx = new bitcoin.Transaction(); 
tx.setOverwinter();
```