### PR TITLE
Bug/optional overwinter

### DIFF
--- a/src/transaction.js
+++ b/src/transaction.js
@@ -28,9 +28,13 @@ function Transaction () {
   this.ins = []
   this.outs = []
   this.joinsplits = []
-  this.versionGroupId = '0x03c48270'
-  this.expiry = 0
-  this.zcash = true
+}
+
+Transaction.prototype.setOverwinter = (expiry, versionGroupId, version) => {
+  this.zcash = true;
+  this.version = Math.max((version||3), 3);
+  this.versionGroupId=(versionGroupId||0x03c48270);
+  this.expiry=(expiry||0);
 }
 
 Transaction.DEFAULT_SEQUENCE = 0xffffffff

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -23,7 +23,7 @@ function vectorSize (someVector) {
 }
 
 function Transaction () {
-  this.version = 3
+  this.version = 1
   this.locktime = 0
   this.ins = []
   this.outs = []

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -488,10 +488,10 @@ TransactionBuilder.prototype.setExpiry = function (expiry) {
   this.tx.expiry = expiry
 }
 
-TransactionBuilder.prototype.setVersionGroupId = function (versiongroupid) {
-  typeforce(types.UInt32, versiongroupid)
+TransactionBuilder.prototype.setVersionGroupId = function (versionGroupId) {
+  typeforce(types.UInt32, versionGroupId)
 
-  this.tx.versiongroupid = versiongroupid
+  this.tx.versionGroupId = versionGroupId
 }
 
 TransactionBuilder.prototype.setLockTime = function (locktime) {


### PR DESCRIPTION
Fixed typos that may have caused some issues. 

setOverwinter() is now a function again and not an array.

Changed line 369 in transaction.js back to their original. Not sure exactly what it does but it seems to work with everything with this change. Needs tested on zcash. If it fails we need to make this more dynamic or configurable.